### PR TITLE
make mCurrentPosition += position in the end of initilizeStack() so that the 4th Card won't repeat twice

### DIFF
--- a/App/src/main/java/com/lal/focusprototype/app/views/CardStackView.java
+++ b/App/src/main/java/com/lal/focusprototype/app/views/CardStackView.java
@@ -125,7 +125,7 @@ public class CardStackView extends RelativeLayout {
             mMyTouchListener = new MyOnTouchListener();
         }
 
-        mCurrentPosition += position - 1;
+        mCurrentPosition += position;
     }
 
     @Override


### PR DESCRIPTION
In the initilizeStack() function you are making mCurrentPosition += position - 1 in then end of the funciton, making the 4th card to repeat twice,

it should be mCurrentPosition += position.

after swiping the first card the stack gets the same 4th card again. Can you see if this is the case, I did use most of your code as it is, and the above change fixed my bug. I believe you will have the same bug as well..
