### PR TITLE
Bugfix: make "choice" true in onChoiceMade() when you "like" an item.

### DIFF
--- a/App/src/main/java/com/lal/focusprototype/app/views/CardStackView.java
+++ b/App/src/main/java/com/lal/focusprototype/app/views/CardStackView.java
@@ -15,7 +15,7 @@ import android.widget.RelativeLayout;
 import com.lal.focusprototype.app.R;
 import com.nineoldandroids.animation.Animator;
 import com.nineoldandroids.animation.AnimatorListenerAdapter;
-import com.nineoldandroids.animation.AnimatorSet;
+import com.nineoldandroids.animonation.AnimatorSet;
 import com.nineoldandroids.animation.ObjectAnimator;
 import com.nineoldandroids.animation.ValueAnimator;
 
@@ -359,6 +359,7 @@ public class CardStackView extends RelativeLayout {
                         }
 
                         int sign = mXDelta > 0 ? +1 : -1;
+                        final boolean finalChoice = mXDelta > 0;
 
                         mBeingDragged= null;
                         mXDelta = 0;
@@ -373,7 +374,7 @@ public class CardStackView extends RelativeLayout {
                             public void onAnimationEnd(Animator animation) {
 
                                 if (mCardStackListener != null){
-                                    boolean choice = getStackChoice();
+                                    boolean choice = finalChoice;
                                     mCardStackListener.onChoiceMade(choice, last);
                                 }
 


### PR DESCRIPTION
right now it is false if you "like" an item or not. mXDelta is reset to 0 before the onChoiceMade logic, so its returning false no matter what.
