### PR TITLE
bugfix: change adapterHasMoreItems as it returns false even if there is ...

### DIFF
--- a/App/src/main/java/com/lal/focusprototype/app/views/CardStackView.java
+++ b/App/src/main/java/com/lal/focusprototype/app/views/CardStackView.java
@@ -167,7 +167,7 @@ public class CardStackView extends RelativeLayout {
     }
 
     private boolean adapterHasMoreItems() {
-        return mCurrentPosition < mAdapter.getCount() - 1;
+        return mCurrentPosition < mAdapter.getCount();
     }
 
     private boolean isTopCard(View card) {


### PR DESCRIPTION
...one last item remaining.

because of the current bug, the last item doesn't show up after swiping the all the remaining items..
